### PR TITLE
Fix all ESLint warnings in opportunityManagement React app

### DIFF
--- a/partner-central-api-sample-codes/opportunityManagement/src/components/AdditionalDetails.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/AdditionalDetails.js
@@ -4,7 +4,6 @@ import {
   Header,
   ColumnLayout,
   Box,
-  Button,
 } from "@cloudscape-design/components";
 
 function AdditionalDetails({ opportunity, awsOpportunity }) {

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/AssociateOpportunity.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/AssociateOpportunity.js
@@ -13,7 +13,6 @@ import {
   Alert,
   Spinner,
   Table,
-  ColumnLayout,
   Checkbox
 } from "@cloudscape-design/components";
 import { getCredentials } from '../utils/sessionStorage';

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/AssociateOpportunityMenu.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/AssociateOpportunityMenu.js
@@ -12,7 +12,6 @@ import {
   Box,
   Alert,
   Spinner,
-  Table,
   Checkbox
 } from "@cloudscape-design/components";
 import { hasCredentials, getOpportunityId, getCredentials } from '../utils/sessionStorage';
@@ -114,10 +113,7 @@ function AssociateOpportunityMenu() {
 
   // Update payloads whenever form data changes
   useEffect(() => {
-    // Import v4 from uuid
     const generatePayloads = async () => {
-        const { v4: uuidv4 } = await import('uuid');
-        
         // Generate associate payload based on selected entity type
         let entityIdentifier = '';
         let entityType = '';
@@ -289,6 +285,7 @@ function AssociateOpportunityMenu() {
             <Box margin={{ top: 'l' }}>
               <Box variant="awsui-key-label">Opportunity ID</Box>
               <Box variant="samp">
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                 <a 
                   href="#" 
                   onClick={(e) => {

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/Contacts.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/Contacts.js
@@ -4,7 +4,6 @@ import {
   Header,
   Table,
   Box,
-  Button,
   Link,
 } from "@cloudscape-design/components";
 

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/CreateAwsOpportunity.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/CreateAwsOpportunity.js
@@ -43,6 +43,7 @@ function CreateAwsOpportunity() {
   
   // Form state
   // Options arrays
+  // eslint-disable-next-line no-unused-vars
   const salesActivitiesOptions = [
     { value: "Conducted POC / Demo", label: "Conducted POC / Demo" },
     { value: "Customer has shown interest in solution", label: "Customer has shown interest in solution" },

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/CreateOpportunity.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/CreateOpportunity.js
@@ -18,12 +18,11 @@ import {
   Alert,
   Checkbox
 } from "@cloudscape-design/components";
-import axios from 'axios';
 
 function CreateOpportunity() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [, setError] = useState(null);
   const [uploadedJson, setUploadedJson] = useState(null);
   const fileInputRef = useRef(null);
   
@@ -124,6 +123,7 @@ function CreateOpportunity() {
   });
   
   // Options for select components
+  // eslint-disable-next-line no-unused-vars
   const salesActivitiesOptions = [
     { value: "Conducted POC / Demo", label: "Conducted POC / Demo" },
     { value: "Customer has shown interest in solution", label: "Customer has shown interest in solution" },
@@ -131,6 +131,7 @@ function CreateOpportunity() {
     { value: "Identified budget", label: "Identified budget" }
   ];
   
+  // eslint-disable-next-line no-unused-vars
   const solutionsOptions = [
     { value: "TestSolution", label: "TestSolution" },
     { value: "New Relic One", label: "New Relic One" },
@@ -138,6 +139,7 @@ function CreateOpportunity() {
     { value: "Dynatrace", label: "Dynatrace" }
   ];
   
+  // eslint-disable-next-line no-unused-vars
   const awsProductsOptions = [
     { value: "AWS CloudWatch", label: "AWS CloudWatch" },
     { value: "Amazon EC2", label: "Amazon EC2" },

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/CustomerDetails.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/CustomerDetails.js
@@ -5,7 +5,6 @@ import {
   ColumnLayout,
   Box,
   Link,
-  Button,
 } from "@cloudscape-design/components";
 
 function CustomerDetails({ opportunity }) {

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/EditOpportunity.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/EditOpportunity.js
@@ -27,7 +27,7 @@ function EditOpportunity() {
   const [opportunity, setOpportunity] = useState(null);
   const [formData, setFormData] = useState({});
   const [jsonPayload, setJsonPayload] = useState('');
-  const [originalJsonPayload, setOriginalJsonPayload] = useState('');
+  const [, setOriginalJsonPayload] = useState('');
 
   useEffect(() => {
     // Check if credentials exist

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/EngagementInvitationDetails.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/EngagementInvitationDetails.js
@@ -11,12 +11,11 @@ import {
   ColumnLayout,
   FormField
 } from "@cloudscape-design/components";
-import { hasCredentials } from '../utils/sessionStorage';
 
 function EngagementInvitationDetails({ invitationId: propInvitationId }) {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [invitationId, setInvitationId] = useState(null);
+  const [invitationId] = useState(null);
   const [invitation, setInvitation] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/GetEngagementInvitation.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/GetEngagementInvitation.js
@@ -9,19 +9,16 @@ import {
   SpaceBetween,
   Button,
   Box,
-  Alert,
-  Spinner,
-  ColumnLayout
+  Alert
 } from "@cloudscape-design/components";
 import { hasCredentials, getEngagementInvitationId, getCredentials } from '../utils/sessionStorage';
 
 function GetEngagementInvitation() {
   const navigate = useNavigate();
   const location = useLocation();
-  const [loading, setLoading] = useState(false);
+  const [loading] = useState(false);
   const [error, setError] = useState(null);
   const [invitationId, setInvitationId] = useState('');
-  const [showDetails, setShowDetails] = useState(false);
 
   useEffect(() => {
     // Check if credentials exist

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/GetOpportunity.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/GetOpportunity.js
@@ -10,8 +10,6 @@ import {
   Button,
   Box,
   Alert,
-  Spinner,
-  ColumnLayout,
   ExpandableSection
 } from "@cloudscape-design/components";
 import { hasCredentials, getOpportunityId, getCredentials, saveOpportunityId } from '../utils/sessionStorage';
@@ -23,26 +21,6 @@ import Overview from './Overview';
 import NextSteps from './NextSteps';
 import TabsSection from './TabsSection';
 import AgentChat from './AgentChat';
-
-// Helper function to clean the response by removing __type attributes
-const cleanResponse = (obj) => {
-  if (!obj) return obj;
-  
-  if (typeof obj !== 'object') return obj;
-  
-  if (Array.isArray(obj)) {
-    return obj.map(item => cleanResponse(item));
-  }
-  
-  const result = {};
-  for (const key in obj) {
-    if (key !== '__type') {
-      result[key] = cleanResponse(obj[key]);
-    }
-  }
-  
-  return result;
-};
 
 function GetOpportunity() {
   const navigate = useNavigate();

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/ListEngagementInvitations.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/ListEngagementInvitations.js
@@ -127,6 +127,7 @@ function ListEngagementInvitations() {
       id: "id",
       header: "Invitation ID",
       cell: item => (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a 
           href="#" 
           onClick={(e) => {

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/NextSteps.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/NextSteps.js
@@ -2,10 +2,8 @@ import React from 'react';
 import {
   Table,
   Header,
-  Button,
   Link,
   Box,
-  ButtonDropdown,
 } from "@cloudscape-design/components";
 
 function NextSteps({ opportunity }) {

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/OpportunitiesList.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/OpportunitiesList.js
@@ -80,6 +80,7 @@ const OpportunitiesList = () => {
       id: 'opportunityId',
       header: 'Opportunity ID',
       cell: item => (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a 
           href="#" 
           onClick={(e) => {

--- a/partner-central-api-sample-codes/opportunityManagement/src/components/StartEngagementFromOpportunityTask.js
+++ b/partner-central-api-sample-codes/opportunityManagement/src/components/StartEngagementFromOpportunityTask.js
@@ -102,6 +102,7 @@ function StartEngagementFromOpportunityTask() {
             <Box margin={{ top: 'l' }}>
               <Box variant="awsui-key-label">Opportunity ID</Box>
               <Box variant="samp">
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                 <a 
                   href="#" 
                   onClick={(e) => {


### PR DESCRIPTION
Remove unused imports (Button, ColumnLayout, Spinner, Table, ButtonDropdown, axios, hasCredentials), drop unused state setters and dead-code variables (uuidv4, cleanResponse, originalJsonPayload, showDetails, setLoading, setInvitationId), and suppress jsx-a11y/anchor-is-valid on three intentional client-side SPA navigation anchors. Also keep reference option arrays (salesActivitiesOptions, solutionsOptions, awsProductsOptions) with eslint-disable so they remain documented. webpack now compiles cleanly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
